### PR TITLE
Core update

### DIFF
--- a/tasks/win.yml
+++ b/tasks/win.yml
@@ -15,5 +15,7 @@
 
 - name: Disable core updatey
   win_shell: |
-    Set-Location -Path "C:\Program Files\Tenable\Nessus Agent"
-   .\nessuscli.exe fix --set disable_core_updates=yes
+    cd "C:\\Program Files\\Tenable\\Nessus Agent"
+    .\\nessuscli.exe fix --set disable_core_updates=yes
+  args:
+    executable: cmd

--- a/tasks/win.yml
+++ b/tasks/win.yml
@@ -13,7 +13,7 @@
     path: "C:\\build-artifacts\\{{ nessus_installer_file[package_type] }}"
     arguments: NESSUS_SERVER="{{nessus_server_url}}:{{nessus_server_port}}" NESSUS_KEY={{nessus_agent_key}} /qn
 
-- name: Disable core updatey
+- name: Disable core update
   win_shell: |
     cd "C:\\Program Files\\Tenable\\Nessus Agent"
     .\\nessuscli.exe fix --set disable_core_updates=yes

--- a/tasks/win.yml
+++ b/tasks/win.yml
@@ -14,5 +14,6 @@
     arguments: NESSUS_SERVER="{{nessus_server_url}}:{{nessus_server_port}}" NESSUS_KEY={{nessus_agent_key}} /qn
 
 - name: Disable core updatey
-  win_command: >
-   path: "C:\Program Files\Tenable\Nessus Agent\nessuscli fix --set disable_core_updates=yes" 
+  win_shell: |
+    Set-Location -Path "C:\Program Files\Tenable\Nessus Agent"
+   .\nessuscli.exe fix --set disable_core_updates=yes

--- a/tasks/win.yml
+++ b/tasks/win.yml
@@ -12,3 +12,7 @@
   win_package:
     path: "C:\\build-artifacts\\{{ nessus_installer_file[package_type] }}"
     arguments: NESSUS_SERVER="{{nessus_server_url}}:{{nessus_server_port}}" NESSUS_KEY={{nessus_agent_key}} /qn
+
+- name: Disable core updatey
+  win_command: >
+   C:\Program Files\Tenable\Nessus Agent\nessuscli fix --set disable_core_updates=yes 

--- a/tasks/win.yml
+++ b/tasks/win.yml
@@ -15,4 +15,4 @@
 
 - name: Disable core updatey
   win_command: >
-   C:\Program Files\Tenable\Nessus Agent\nessuscli fix --set disable_core_updates=yes 
+   path: "C:\Program Files\Tenable\Nessus Agent\nessuscli fix --set disable_core_updates=yes" 


### PR DESCRIPTION
Nessus agent in windows ami was down graded to a lower version after installation, to prevent this we need to disable core update during nessus installation in windows. I have added this at the end of nessus ansible role for windows. See details in ticket
https://github.com/GSA/ise-engagements/issues/54